### PR TITLE
Add Travis CI signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 This simple PHP code will allow you to send Travis-CI build notifications to your discord channel. 
 
-## Warning
-This does not attempt to verify that the webhook request came from Travis-CI, although they have instructions [here](https://docs.travis-ci.com/user/notifications/#Verifying-Webhook-requests) on how to do so. Feel free to make a pull request.
-
 ## Screenshot
 ![](/../images/discord_screenshot.png)
 

--- a/travis-ci.php
+++ b/travis-ci.php
@@ -23,6 +23,14 @@ if ($_SERVER['CONTENT_TYPE'] != 'application/x-www-form-urlencoded') {
 
 $fullPostData = $_POST['payload'];
 
+$travisApiConfig = json_decode(file_get_contents('https://api.travis-ci.org/config'));
+$publicKey = $travisApiConfig->config->notifications->webhook->public_key;
+$signature = base64_decode($_SERVER['HTTP_SIGNATURE']);
+if (openssl_verify($fullPostData, $signature, $publicKey) != 1) {
+  header('HTTP/1.0 401 Access Denied');
+  exit();
+}
+
 if ($fullPostData == '') {
   header('HTTP/1.0 400 Bad request');
   echo "No data submitted\n";


### PR DESCRIPTION
This pull request adds verification of the signature Travis provides for webhooks.
It pulls Travis' public key on every request and verifies the request with it. This way the script cannot be abused to spam discord channels.